### PR TITLE
Enhance Discord RPC display

### DIFF
--- a/mlb-discord-rpc.py
+++ b/mlb-discord-rpc.py
@@ -206,7 +206,7 @@ def get_next_game_info(team_id, local_tz, abbr_map):
     return None, None, None, None, (None, None), (None, None)
 
 def get_previous_game_score(team_id, abbr_map):
-    """Return a string with the previous game's final score."""
+    """Return the last game's score and series result if available."""
     try:
         now_utc = datetime.now(timezone.utc)
         start_date = (now_utc - timedelta(days=7)).date()
@@ -237,7 +237,11 @@ def get_previous_game_score(team_id, abbr_map):
             away_abbr = abbr_map.get(away["team"]["id"], "???")
             home_score = home.get("score", 0)
             away_score = away.get("score", 0)
-            return f"Prev: {away_abbr} {away_score} - {home_abbr} {home_score}"
+            result = f"Prev: {away_abbr} {away_score} - {home_abbr} {home_score}"
+            series_result = get_series_result(team_id, last_game, abbr_map)
+            if series_result:
+                result += f" • {series_result}"
+            return result
     except RequestException as e:
         print("Failed to fetch previous game:", e)
     return None


### PR DESCRIPTION
## Summary
- show series result at end of series
- add bullet separator between team name and record
- keep the same style for fallback presence strings

## Testing
- `python -m py_compile mlb-discord-rpc.py`


------
https://chatgpt.com/codex/tasks/task_e_6862d2479ba48324a3bc1d4f1c300344