### PR TITLE
Add remote server UI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Example:
 python mlb-discord-rpc.py --team TOR
 ```
 
+Or use `remote_ui_server.py` on another machine to manage the script through a
+web interface.
+
 ---
 
 ## Options & Configuration
@@ -85,6 +88,8 @@ You can configure **mlb-discord-rpc** via command-line options, a `config.toml` 
   Override the detected local timezone. Use [IANA timezone names](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (e.g., `America/Toronto`).
 * `--live-only`
   Only show your Discord status when your team has a live game.
+* `--remote-url <URL>`
+  Send presence updates to a remote RPC server instead of local Discord.
 
 **Example:**
 
@@ -102,6 +107,7 @@ Example:
 team = "TOR"
 timezone = "America/Toronto"
 live_only = true
+remote_url = "http://<pc-ip>:6463"
 
 [display]
 base_icon_filled = "🟦"
@@ -115,6 +121,9 @@ idle_interval = 90
 * `team` - Team abbreviation (required)
 * `timezone` - IANA timezone string (optional)
 * `live_only` - Only display presence when game is live (optional)
+* `remote_url` - URL of remote RPC server (optional). If you run
+  `remote_ui_server.py` on another machine, set this to the address of
+  `remote_rpc_server.py` on the Discord PC.
 * `[display]` - Customize base icons
 * `[refresh]` - Customize update intervals in seconds
 
@@ -138,6 +147,16 @@ CLIENT_ID=your_discord_client_id_here
 1. Set your `CLIENT_ID` in `.env`.
 2. Optionally configure your team and preferences in `config.toml`.
 3. Or run directly with command-line options.
+4. To run from another machine, start `remote_rpc_server.py` on the Discord PC
+   and use `remote_ui_server.py` on the remote host. Configure the remote URL
+   through the web UI at `http://<rpi-ip>:8080/` and point it to
+   `http://<pc-ip>:6463`.
+   Visit `http://<pc-ip>:6463/` if you ever want to run the script locally
+   instead of remotely.
+
+`remote_rpc_server.py` now serves a simple web UI for choosing **Local** or
+**Remote** mode. In local mode it runs `mlb-discord-rpc.py` automatically with
+your saved settings.
 
 **Enjoy seamless MLB presence on Discord!**
 

--- a/remote_rpc_server.py
+++ b/remote_rpc_server.py
@@ -1,0 +1,171 @@
+import os
+import json
+import sys
+import time
+import subprocess
+from urllib.parse import parse_qs
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from dotenv import load_dotenv
+from pypresence import Presence
+from pypresence.exceptions import PipeClosed
+
+load_dotenv()
+CLIENT_ID = os.getenv("CLIENT_ID")
+if not CLIENT_ID:
+    print("CLIENT_ID is not set. Please add it to your .env file.")
+    exit(1)
+
+
+def connect_rpc():
+    while True:
+        try:
+            rpc = Presence(CLIENT_ID)
+            rpc.response_timeout = 5
+            rpc.connect()
+            print("Connected to Discord RPC.")
+            return rpc
+        except Exception:
+            print("Waiting for Discord... retrying in 5s.")
+            time.sleep(5)
+
+
+rpc = connect_rpc()
+
+
+settings = {
+    "mode": "remote",
+    "remote_url": "",
+    "team": "",
+    "timezone": "",
+    "live_only": False,
+}
+
+process = None
+
+
+def start_local():
+    global process
+    if process or not settings["team"]:
+        return
+    args = [
+        sys.executable,
+        os.path.join(os.path.dirname(__file__), "mlb-discord-rpc.py"),
+        "--team",
+        settings["team"],
+    ]
+    if settings["timezone"]:
+        args += ["--tz", settings["timezone"]]
+    if settings["live_only"]:
+        args.append("--live-only")
+    if settings["remote_url"]:
+        args += ["--remote-url", settings["remote_url"]]
+    process = subprocess.Popen(args)
+
+
+def stop_local():
+    global process
+    if process:
+        process.terminate()
+        process.wait()
+        process = None
+
+
+def apply_settings():
+    if settings["mode"] == "local":
+        start_local()
+    else:
+        stop_local()
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send_html(self, html):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(html.encode())
+
+    def do_GET(self):
+        if self.path != "/":
+            self.send_response(404)
+            self.end_headers()
+            return
+        live_checked = "checked" if settings["live_only"] else ""
+        remote_sel = "selected" if settings["mode"] == "remote" else ""
+        local_sel = "selected" if settings["mode"] == "local" else ""
+        html = (
+            "<html><body>\n"
+            "<h1>RPC Server</h1>\n"
+            "<form method='post' action='/config'>\n"
+            "Mode: <select name='mode'>\n"
+            f"<option value='remote' {remote_sel}>remote</option>\n"
+            f"<option value='local' {local_sel}>local</option>\n"
+            "</select><br/>\n"
+            "Remote URL: <input name='remote_url' value='"
+            f"{settings['remote_url']}'/><br/>\n"
+            f"Team: <input name='team' value='{settings['team']}'/><br/>\n"
+            "Timezone: <input name='timezone' value='"
+            f"{settings['timezone']}'/><br/>\n"
+            "Live only: <input type='checkbox' name='live_only' "
+            f"{live_checked}/><br/>\n"
+            "<input type='submit' value='Save'/>\n"
+            "</form></body></html>"
+        )
+        self._send_html(html)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        data = self.rfile.read(length) if length else b""
+
+        if self.path == "/config":
+            params = parse_qs(data.decode()) if data else {}
+            settings["mode"] = params.get("mode", ["remote"])[0]
+            settings["remote_url"] = params.get("remote_url", [""])[0]
+            settings["team"] = params.get("team", [""])[0].upper()
+            settings["timezone"] = params.get("timezone", [""])[0]
+            settings["live_only"] = "live_only" in params
+            apply_settings()
+            self.send_response(302)
+            self.send_header("Location", "/")
+            self.end_headers()
+            return
+
+        try:
+            payload = json.loads(data.decode()) if data else {}
+        except json.JSONDecodeError:
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        try:
+            if self.path == "/update":
+                rpc.update(**payload)
+            elif self.path == "/clear":
+                rpc.clear()
+            else:
+                self.send_response(404)
+                self.end_headers()
+                return
+            self.send_response(204)
+        except PipeClosed:
+            print("Lost Discord RPC connection. Reconnecting...")
+            global rpc
+            rpc = connect_rpc()
+            self.send_response(204)
+        except Exception as e:
+            print("Error handling request:", e)
+            self.send_response(500)
+        self.end_headers()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Discord RPC bridge server")
+    parser.add_argument("--host", default="0.0.0.0", help="listen host")
+    parser.add_argument("--port", type=int, default=6463, help="listen port")
+    args = parser.parse_args()
+
+    server = HTTPServer((args.host, args.port), Handler)
+    apply_settings()
+    print(f"Listening on {args.host}:{args.port}")
+    server.serve_forever()

--- a/remote_ui_server.py
+++ b/remote_ui_server.py
@@ -1,0 +1,97 @@
+import os
+import sys
+import subprocess
+from urllib.parse import parse_qs
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+def start_script():
+    global process
+    if process:
+        process.terminate()
+        process.wait()
+        process = None
+    if not settings["team"] or not settings["remote_url"]:
+        return
+    args = [
+        sys.executable,
+        os.path.join(os.path.dirname(__file__), "mlb-discord-rpc.py"),
+        "--team",
+        settings["team"],
+        "--remote-url",
+        settings["remote_url"],
+    ]
+    if settings["timezone"]:
+        args += ["--tz", settings["timezone"]]
+    if settings["live_only"]:
+        args.append("--live-only")
+    process = subprocess.Popen(args)
+
+
+settings = {
+    "remote_url": "",
+    "team": "",
+    "timezone": "",
+    "live_only": False,
+}
+process = None
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send_html(self, html):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(html.encode())
+
+    def do_GET(self):
+        if self.path != "/":
+            self.send_response(404)
+            self.end_headers()
+            return
+        live_checked = "checked" if settings["live_only"] else ""
+        html = (
+            "<html><body>\n"
+            "<h1>RPC Remote Control</h1>\n"
+            "<form method='post' action='/config'>\n"
+            "Remote URL: <input name='remote_url' value='"
+            f"{settings['remote_url']}'/><br/>\n"
+            f"Team: <input name='team' value='{settings['team']}'/><br/>\n"
+            "Timezone: <input name='timezone' value='"
+            f"{settings['timezone']}'/><br/>\n"
+            "Live only: <input type='checkbox' name='live_only' "
+            f"{live_checked}/><br/>\n"
+            "<input type='submit' value='Save'/>\n"
+            "</form></body></html>"
+        )
+        self._send_html(html)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        data = self.rfile.read(length) if length else b""
+        if self.path == "/config":
+            params = parse_qs(data.decode()) if data else {}
+            settings["remote_url"] = params.get("remote_url", [""])[0]
+            settings["team"] = params.get("team", [""])[0].upper()
+            settings["timezone"] = params.get("timezone", [""])[0]
+            settings["live_only"] = "live_only" in params
+            start_script()
+            self.send_response(302)
+            self.send_header("Location", "/")
+            self.end_headers()
+            return
+        self.send_response(404)
+        self.end_headers()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run RPC script with web UI")
+    parser.add_argument("--host", default="0.0.0.0", help="listen host")
+    parser.add_argument("--port", type=int, default=8080, help="listen port")
+    args = parser.parse_args()
+
+    server = HTTPServer((args.host, args.port), Handler)
+    print(f"Listening on {args.host}:{args.port}")
+    server.serve_forever()


### PR DESCRIPTION
## Summary
- provide a small web UI in `remote_rpc_server.py`
- support running the regular script automatically from the server
- document the new UI in the quick-start guide
- add flake8 config and clean up style issues
- add remote web interface to control the script on a separate machine

## Testing
- `flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862f9d02220832486d01aa5b525cd9a