### PR TITLE
Fix pitcher detection

### DIFF
--- a/mlb-discord-rpc.py
+++ b/mlb-discord-rpc.py
@@ -444,18 +444,25 @@ def build_presence(game, team_info, local_tz, icons, abbr_map):
 
     pitcher = get_pitcher(game, team_info["id"])
     batter = get_batter(game)
+    offense_team_id = linescore.get("offense", {}).get("team", {}).get("id")
+    team_is_offense = offense_team_id == team_info["id"]
 
     if game["status"]["abstractGameState"] == "Live":
         state_str = f"{inning_str} | Bases {base_status} | {outs} Out{'s' if outs > 1 else ''}"
         short_p = shorten_name(pitcher) if pitcher else None
         short_b = shorten_name(batter) if batter else None
-        if short_p and short_b:
-            state_str += f" | {short_p} pitching {short_b}"
-        else:
-            if short_p:
-                state_str += f" | {short_p} pitching"
-            if short_b:
-                state_str += f" | {short_b} batting"
+        if short_p or short_b:
+            if team_is_offense:
+                first, second, verb = short_b, short_p, "batting"
+            else:
+                first, second, verb = short_p, short_b, "pitching"
+
+            if first and second:
+                state_str += f" | {first} {verb} {second}"
+            elif first:
+                state_str += f" | {first} {verb}"
+            elif second:
+                state_str += f" | {second} {'pitching' if team_is_offense else 'batting'}"
     elif status in ["Final", "Game Over"]:
         state_str = "FINAL"
         next_game = get_next_game_datetime(team_info["id"], local_tz, abbr_map)

--- a/mlb-discord-rpc.py
+++ b/mlb-discord-rpc.py
@@ -356,12 +356,15 @@ def get_team_record(team_id, game=None):
     return get_team_record_from_api(team_id)
 
 def get_pitcher(game, team_id):
+    """Return the current pitcher's full name if available."""
     try:
-        players = game["boxscore"]["teams"]
-        side = "home" if game["teams"]["home"]["team"]["id"] == team_id else "away"
-        for pdata in players["away" if side == "home" else "home"]["players"].values():
-            if pdata.get("position", {}).get("code") == "P" and pdata.get("stats", {}).get("pitching", {}).get("gamesPitched", 0) > 0:
-                return pdata["person"]["fullName"]
+        pitcher_id = game.get("linescore", {}).get("defense", {}).get("pitcher", {}).get("id")
+        if not pitcher_id:
+            return None
+        for side in ["home", "away"]:
+            for pdata in game["boxscore"]["teams"][side]["players"].values():
+                if pdata.get("person", {}).get("id") == pitcher_id:
+                    return pdata.get("person", {}).get("fullName")
     except KeyError:
         pass
     return None

--- a/mlb-discord-rpc.py
+++ b/mlb-discord-rpc.py
@@ -399,6 +399,16 @@ def get_batter(game):
         pass
     return None
 
+def shorten_name(name):
+    """Return player's first initial and last name to save space."""
+    try:
+        parts = name.split()
+        if len(parts) > 1:
+            return f"{parts[0][0]}. {parts[-1]}"
+    except Exception:
+        pass
+    return name
+
 def build_presence(game, team_info, local_tz, icons, abbr_map):
     linescore = game.get("linescore", {})
     home = game["teams"]["home"]
@@ -437,10 +447,15 @@ def build_presence(game, team_info, local_tz, icons, abbr_map):
 
     if game["status"]["abstractGameState"] == "Live":
         state_str = f"{inning_str} | Bases {base_status} | {outs} Out{'s' if outs > 1 else ''}"
-        if pitcher:
-            state_str += f" | P: {pitcher}"
-        if batter:
-            state_str += f" | B: {batter}"
+        short_p = shorten_name(pitcher) if pitcher else None
+        short_b = shorten_name(batter) if batter else None
+        if short_p and short_b:
+            state_str += f" | {short_p} vs {short_b}"
+        else:
+            if short_p:
+                state_str += f" | P {short_p}"
+            if short_b:
+                state_str += f" | B {short_b}"
     elif status in ["Final", "Game Over"]:
         state_str = "FINAL"
         next_game = get_next_game_datetime(team_info["id"], local_tz, abbr_map)

--- a/mlb-discord-rpc.py
+++ b/mlb-discord-rpc.py
@@ -355,30 +355,47 @@ def get_team_record(team_id, game=None):
             pass
     return get_team_record_from_api(team_id)
 
-def get_pitcher(game, team_id):
+def get_pitcher(game, team_id=None):
     """Return the current pitcher's full name if available."""
     try:
-        pitcher_id = game.get("linescore", {}).get("defense", {}).get("pitcher", {}).get("id")
+        pitcher = game.get("linescore", {}).get("defense", {}).get("pitcher")
+        if isinstance(pitcher, dict):
+            name = pitcher.get("fullName")
+            if name:
+                return name
+            pitcher_id = pitcher.get("id")
+        else:
+            pitcher_id = pitcher
+
         if not pitcher_id:
             return None
         for side in ["home", "away"]:
             for pdata in game["boxscore"]["teams"][side]["players"].values():
                 if pdata.get("person", {}).get("id") == pitcher_id:
                     return pdata.get("person", {}).get("fullName")
-    except KeyError:
+    except (KeyError, TypeError):
         pass
     return None
 
 def get_batter(game):
+    """Return the current batter's full name if available."""
     try:
-        batter_id = game["linescore"].get("offense", {}).get("batter", {}).get("id")
+        batter = game.get("linescore", {}).get("offense", {}).get("batter")
+        if isinstance(batter, dict):
+            name = batter.get("fullName")
+            if name:
+                return name
+            batter_id = batter.get("id")
+        else:
+            batter_id = batter
+
         if not batter_id:
             return None
         for side in ["home", "away"]:
             for pdata in game["boxscore"]["teams"][side]["players"].values():
-                if pdata["person"]["id"] == batter_id:
-                    return pdata["person"]["fullName"]
-    except KeyError:
+                if pdata.get("person", {}).get("id") == batter_id:
+                    return pdata.get("person", {}).get("fullName")
+    except (KeyError, TypeError):
         pass
     return None
 

--- a/mlb-discord-rpc.py
+++ b/mlb-discord-rpc.py
@@ -400,11 +400,11 @@ def get_batter(game):
     return None
 
 def shorten_name(name):
-    """Return player's first initial and last name to save space."""
+    """Return player's last name to keep the display concise."""
     try:
         parts = name.split()
-        if len(parts) > 1:
-            return f"{parts[0][0]}. {parts[-1]}"
+        if parts:
+            return parts[-1]
     except Exception:
         pass
     return name
@@ -450,12 +450,12 @@ def build_presence(game, team_info, local_tz, icons, abbr_map):
         short_p = shorten_name(pitcher) if pitcher else None
         short_b = shorten_name(batter) if batter else None
         if short_p and short_b:
-            state_str += f" | {short_p} vs {short_b}"
+            state_str += f" | {short_p} pitching {short_b}"
         else:
             if short_p:
-                state_str += f" | P {short_p}"
+                state_str += f" | {short_p} pitching"
             if short_b:
-                state_str += f" | B {short_b}"
+                state_str += f" | {short_b} batting"
     elif status in ["Final", "Game Over"]:
         state_str = "FINAL"
         next_game = get_next_game_datetime(team_info["id"], local_tz, abbr_map)


### PR DESCRIPTION
## Summary
- fetch current pitcher's ID from the linescore defense section to reliably show `P: <pitcher>`

## Testing
- `python -m py_compile mlb-discord-rpc.py`


------
https://chatgpt.com/codex/tasks/task_e_68631034a04c8324835915aeab3c73fa