### PR TITLE
Add ball-strike count to live presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 * [Options & Configuration](#options--configuration)
 
 ## Overview
-**mlb-discord-rpc** shows live Major League Baseball game updates as your Discord status. It uses Discord Rich Presence to display real-time scores, game status, and player info for your favorite team while you use Discord. When no live game is detected, it displays the upcoming matchup with your opponent's logo and shows the score from the previous game. The large and small image tooltips include each team's win–loss record. Pre-game statuses now also show the scheduled start time. Live game updates also show the current ball and strike count for the batter.
+**mlb-discord-rpc** shows live Major League Baseball game updates as your Discord status. It uses Discord Rich Presence to display real-time scores, game status, and player info for your favorite team while you use Discord. When no live game is detected, it displays the upcoming matchup with your opponent's logo and shows the score from the previous game. The large and small image tooltips include each team's win–loss record. Pre-game statuses now also show the scheduled start time. Live game updates display the current ball and strike count for the batter only during active half-innings.
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 * [Options & Configuration](#options--configuration)
 
 ## Overview
-**mlb-discord-rpc** shows live Major League Baseball game updates as your Discord status. It uses Discord Rich Presence to display real-time scores, game status, and player info for your favorite team while you use Discord. When no live game is detected, it displays the upcoming matchup with your opponent's logo and shows the score from the previous game. The large and small image tooltips include each team's win–loss record. Pre-game statuses now also show the scheduled start time. Live game updates display the current ball and strike count for the batter only during active half-innings.
+**mlb-discord-rpc** shows live Major League Baseball game updates as your Discord status. It uses Discord Rich Presence to display real-time scores, game status, and player info for your favorite team while you use Discord. When no live game is detected, it displays the upcoming matchup with your opponent's logo and shows the score from the previous game. The large and small image tooltips include each team's win–loss record. Pre-game statuses now also show the scheduled start time. Live game updates display the current ball and strike count for the batter only during active half-innings, and show which players are up next between innings.
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 * [Options & Configuration](#options--configuration)
 
 ## Overview
-**mlb-discord-rpc** shows live Major League Baseball game updates as your Discord status. It uses Discord Rich Presence to display real-time scores, game status, and player info for your favorite team while you use Discord. When no live game is detected, it displays the upcoming matchup with your opponent's logo and shows the score from the previous game. The large and small image tooltips include each team's win–loss record. Pre-game statuses now also show the scheduled start time.
+**mlb-discord-rpc** shows live Major League Baseball game updates as your Discord status. It uses Discord Rich Presence to display real-time scores, game status, and player info for your favorite team while you use Discord. When no live game is detected, it displays the upcoming matchup with your opponent's logo and shows the score from the previous game. The large and small image tooltips include each team's win–loss record. Pre-game statuses now also show the scheduled start time. Live game updates also show the current ball and strike count for the batter.
 
 ## Screenshots
 

--- a/mlb-discord-rpc.py
+++ b/mlb-discord-rpc.py
@@ -470,21 +470,18 @@ def build_presence(game, team_info, local_tz, icons, abbr_map):
         short_p = shorten_name(pitcher) if pitcher else None
         short_b = shorten_name(batter) if batter else None
 
-        batter_display = short_b
-        show_count = inning_state.lower() in ("top", "bottom")
-        if (
-            show_count
+        show_count = (
+            inning_state.lower() in ("top", "bottom")
             and short_b is not None
             and balls is not None
             and strikes is not None
-        ):
-            batter_display = f"{short_b} ({balls}-{strikes})"
+        )
 
-        if short_p or batter_display:
+        if short_p or short_b:
             if team_is_offense:
-                first, second, verb = batter_display, short_p, "batting"
+                first, second, verb = short_b, short_p, "batting"
             else:
-                first, second, verb = short_p, batter_display, "pitching"
+                first, second, verb = short_p, short_b, "pitching"
 
             if first and second:
                 live_str += f" | {first} {verb} {second}"
@@ -492,6 +489,9 @@ def build_presence(game, team_info, local_tz, icons, abbr_map):
                 live_str += f" | {first} {verb}"
             elif second:
                 live_str += f" | {second} {'pitching' if team_is_offense else 'batting'}"
+
+            if show_count:
+                live_str += f" ({balls}-{strikes})"
         state_parts.append(live_str)
     elif status in ["Final", "Game Over"]:
         next_game = get_next_game_datetime(team_info["id"], local_tz, abbr_map)

--- a/mlb-discord-rpc.py
+++ b/mlb-discord-rpc.py
@@ -476,6 +476,7 @@ def build_presence(game, team_info, local_tz, icons, abbr_map):
             and balls is not None
             and strikes is not None
         )
+        show_next_up = inning_state.lower() not in ("top", "bottom")
 
         if short_p or short_b:
             if team_is_offense:
@@ -483,12 +484,14 @@ def build_presence(game, team_info, local_tz, icons, abbr_map):
             else:
                 first, second, verb = short_p, short_b, "pitching"
 
+            prefix = "Next up: " if show_next_up else ""
+
             if first and second:
-                live_str += f" | {first} {verb} {second}"
+                live_str += f" | {prefix}{first} {verb} {second}"
             elif first:
-                live_str += f" | {first} {verb}"
+                live_str += f" | {prefix}{first} {verb}"
             elif second:
-                live_str += f" | {second} {'pitching' if team_is_offense else 'batting'}"
+                live_str += f" | {prefix}{second} {'pitching' if team_is_offense else 'batting'}"
 
             if show_count:
                 live_str += f" ({balls}-{strikes})"

--- a/mlb-discord-rpc.py
+++ b/mlb-discord-rpc.py
@@ -471,7 +471,13 @@ def build_presence(game, team_info, local_tz, icons, abbr_map):
         short_b = shorten_name(batter) if batter else None
 
         batter_display = short_b
-        if short_b is not None and balls is not None and strikes is not None:
+        show_count = inning_state.lower() in ("top", "bottom")
+        if (
+            show_count
+            and short_b is not None
+            and balls is not None
+            and strikes is not None
+        ):
             batter_display = f"{short_b} ({balls}-{strikes})"
 
         if short_p or batter_display:

--- a/mlb-discord-rpc.py
+++ b/mlb-discord-rpc.py
@@ -461,16 +461,24 @@ def build_presence(game, team_info, local_tz, icons, abbr_map):
     offense_team_id = linescore.get("offense", {}).get("team", {}).get("id")
     team_is_offense = offense_team_id == team_info["id"]
 
+    balls = linescore.get("balls")
+    strikes = linescore.get("strikes")
+
     state_parts = []
     if game["status"]["abstractGameState"] == "Live":
         live_str = f"{inning_str} | Bases {base_status} | {outs} Out{'s' if outs > 1 else ''}"
         short_p = shorten_name(pitcher) if pitcher else None
         short_b = shorten_name(batter) if batter else None
-        if short_p or short_b:
+
+        batter_display = short_b
+        if short_b is not None and balls is not None and strikes is not None:
+            batter_display = f"{short_b} ({balls}-{strikes})"
+
+        if short_p or batter_display:
             if team_is_offense:
-                first, second, verb = short_b, short_p, "batting"
+                first, second, verb = batter_display, short_p, "batting"
             else:
-                first, second, verb = short_p, short_b, "pitching"
+                first, second, verb = short_p, batter_display, "pitching"
 
             if first and second:
                 live_str += f" | {first} {verb} {second}"


### PR DESCRIPTION
## Summary
- include balls and strikes from linescore when building live presence
- document that live status now shows ball/strike count

## Testing
- `python -m py_compile mlb-discord-rpc.py`

------
https://chatgpt.com/codex/tasks/task_e_6868827a19808324812ff664e383b752